### PR TITLE
Add github action to build and test

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -10,7 +10,7 @@ jobs:
 
     runs-on: ubuntu-latest
     env:
-      luceeVersion: 5.3.9.166 #5.3.10.97
+      luceeVersion: 5.3.10.97
 
     steps:
     - uses: actions/checkout@v3
@@ -69,3 +69,4 @@ jobs:
       env:
         testLabels: mariaDb
         testAdditional: ${{ github.workspace }}/test
+        testSuiteExtend: org.lucee.cfml.test.LuceeTestCase,testbox.system.BaseSpec

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -1,0 +1,71 @@
+# This workflow will build a Java project with Ant
+# For more information see: https://help.github.com/actions/language-and-framework-guides/building-and-testing-java-with-ant
+
+name: Java CI
+
+on: [push, pull_request,workflow_dispatch]
+
+jobs:
+  build:
+
+    runs-on: ubuntu-latest
+    env:
+      luceeVersion: 5.3.9.166 #5.3.10.97
+
+    steps:
+    - uses: actions/checkout@v3
+    - name: Set up JDK 11
+      uses: actions/setup-java@v3
+      with:
+        java-version: '11'
+        distribution: 'adopt'
+    - name: Shutdown Ubuntu MySQL (SUDO)
+      run: sudo service mysql stop 
+    - name: Setup MariaDB
+      uses: getong/mariadb-action@v1.1
+      with:
+         mysql user: lucee
+         mysql password: pass
+         mysql database: tests
+      env:
+         INPUT_MYSQL_USER: lucee
+         INPUT_MYSQL_PASSWORD: pass
+         INPUT_MYSQL_DATABASE: tests
+    - name: Cache Maven packages
+      uses: actions/cache@v3
+      with:
+        path: ~/.m2
+        key: lucee-script-runner-maven-cache
+    - name: Cache Lucee files
+      uses: actions/cache@v3
+      with:
+        path: _actions/lucee/script-runner/main/lucee-download-cache
+        key: lucee-downloads-${{ env.luceeVersion }}
+        restore-keys: |
+          lucee-downloads
+    - name: Build with script runner
+      uses: lucee/script-runner@main
+      with:
+        webroot: ${{ github.workspace }}/build
+        execute: /index.cfm
+        luceeVersion: ${{ env.luceeVersion }}
+    - name: Upload Artifact
+      uses: actions/upload-artifact@v3
+      with:
+        name: mariadb-lex
+        path: ./*.lex
+    - name: Checkout Lucee
+      uses: actions/checkout@v3
+      with:
+        repository: lucee/lucee
+        path: lucee
+    - name: Run Lucee Test Suite (testLabels="mariaDb")
+      uses: lucee/script-runner@main
+      with:
+        webroot: ${{ github.workspace }}/lucee/test
+        execute: /bootstrap-tests.cfm
+        luceeVersion: ${{ env.luceeVersion }}
+        extensionDir: ${{ github.workspace }}/
+      env:
+        testLabels: mariaDb
+        testAdditional: ${{ github.workspace }}/test

--- a/build/index.cfm
+++ b/build/index.cfm
@@ -1,0 +1,8 @@
+<cfscript>
+    systemOutput("Building MariaDB extension", true);
+    task =  new Task();
+    //new task().run( getDirectoryFromPath( getDirectoryFromPath( getDirectoryFromPath( getCurrentTemplatePath() ) ) ) ); 
+    task.run( expandPath("../" ) ); 
+
+    systemOutput("Finished building extension", true);
+</cfscript>

--- a/build/task.cfc
+++ b/build/task.cfc
@@ -2,8 +2,13 @@ component{
 
 	property name="rootPath";
 
-	void function run(){
-		variables.rootPath = fileSystemUtil.resolvePath( "../" );
+	void function run(rootPath=""){
+		if ( isEmpty( arguments.rootPath ) )
+			variables.rootPath = fileSystemUtil.resolvePath( "../" );
+		else {
+			variables.rootPath = arguments.rootPath;
+		}
+		systemOutput("Build root path: [#variables.rootPath#]", true);
 		generateLexFile();
 	}
 

--- a/test/tests/mariaDb.cfc
+++ b/test/tests/mariaDb.cfc
@@ -1,4 +1,4 @@
-component extends="testbox.system.BaseSpec" labels="mariaDb" {
+component extends="org.lucee.cfml.test.LuceeTestCase" labels="mariaDb" {
 
 	private string function getClassName( required object object ){
 		return GetMetaData( arguments.object ).getCanonicalName()

--- a/test/tests/mariaDb.cfc
+++ b/test/tests/mariaDb.cfc
@@ -1,4 +1,4 @@
-component extends="org.lucee.cfml.test.LuceeTestCase" labels="mariaDb" {
+component extends="testbox.system.BaseSpec" labels="mariaDb" {
 
 	private string function getClassName( required object object ){
 		return GetMetaData( arguments.object ).getCanonicalName()


### PR DESCRIPTION
- had to move the suite test case to a subdir, as the lucee test suite skips any tests in a folder with an `Application.cfc`

one test is failing

 [java]    [script] can add and retrieve a bit value correctly
     [java]    [script] 
     [java]    [script] 	Failed: Expected [java.lang.Boolean] but received [java.lang.Double]
     [java]    [script] 	/home/runner/work/lucee-mariadb/lucee-mariadb/test/tests/mariaDb.cfc:66
     [java]    [script] 	/home/runner/work/lucee-mariadb/lucee-mariadb/lucee/test/_testRunner.cfc:409
     [java]    [script] 	/home/runner/work/lucee-mariadb/lucee-mariadb/lucee/test/run-tests.cfm:218
     [java]    [script] 	/bootstrap-tests.cfm:108